### PR TITLE
Fix vips_area_unref error and add stress test for blob handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,9 @@ let package = Package(
         .executableTarget(name: "vips-tool",
             dependencies: ["VIPS", "Cvips"]
         ),
+        .executableTarget(name: "stress_test",
+            dependencies: ["VIPS", "Cvips"]
+        ),
         .testTarget(
             name: "VIPSTests",
             dependencies: ["VIPS"],

--- a/Sources/VIPS/Core/VIPS.swift
+++ b/Sources/VIPS/Core/VIPS.swift
@@ -889,7 +889,7 @@ extension VIPSImage {
         let areaPtr = shim_vips_area(blob)
         let buffer = UnsafeRawBufferPointer(start: areaPtr!.pointee.data, count: Int(areaPtr!.pointee.length))
         
-        defer { vips_area_unref(shim_vips_area(blob)) }
+        // Note: Don't manually unref output blobs - vips_object_unref_outputs handles it
         
         return Array(buffer)
     }
@@ -915,7 +915,7 @@ extension VIPSImage {
         let areaPtr = shim_vips_area(blob)
         let buffer = UnsafeRawBufferPointer(start: areaPtr!.pointee.data, count: Int(areaPtr!.pointee.length))
         
-        defer { vips_area_unref(shim_vips_area(blob)) }
+        // Note: Don't manually unref output blobs - vips_object_unref_outputs handles it
         
         return Array(buffer)
     }
@@ -942,7 +942,7 @@ extension VIPSImage {
         let areaPtr = shim_vips_area(blob)
         let buffer = UnsafeRawBufferPointer(start: areaPtr!.pointee.data, count: Int(areaPtr!.pointee.length))
         
-        defer { vips_area_unref(shim_vips_area(blob)) }
+        // Note: Don't manually unref output blobs - vips_object_unref_outputs handles it
         
         return Array(buffer)
     }
@@ -1012,7 +1012,7 @@ extension VIPSImage {
         let areaPtr = shim_vips_area(blob)
         let buffer = UnsafeRawBufferPointer(start: areaPtr!.pointee.data, count: Int(areaPtr!.pointee.length))
         
-        defer { vips_area_unref(shim_vips_area(blob)) }
+        // Note: Don't manually unref output blobs - vips_object_unref_outputs handles it
         
         return Array(buffer)
     }
@@ -1063,7 +1063,7 @@ extension VIPSImage {
         let areaPtr = shim_vips_area(blob)
         let buffer = UnsafeRawBufferPointer(start: areaPtr!.pointee.data, count: Int(areaPtr!.pointee.length))
 
-        defer { vips_area_unref(shim_vips_area(blob)) }
+        // Note: Don't manually unref output blobs - vips_object_unref_outputs handles it
 
         return Array(buffer)
     }
@@ -1085,7 +1085,7 @@ extension VIPSImage {
         let areaPtr = shim_vips_area(blob)
         let buffer = UnsafeRawBufferPointer(start: areaPtr!.pointee.data, count: Int(areaPtr!.pointee.length))
         
-        defer { vips_area_unref(shim_vips_area(blob)) }
+        // Note: Don't manually unref output blobs - vips_object_unref_outputs handles it
         
         return Array(buffer)
     }

--- a/Sources/stress_test/main.swift
+++ b/Sources/stress_test/main.swift
@@ -1,0 +1,34 @@
+import VIPS
+
+// Stress test to trigger the vips_area_unref assertion
+func stressTestBlobHandling() throws {
+    try VIPS.start()
+    
+    // Create test image data
+    let width = 100
+    let height = 100
+    let data = Array(repeating: UInt8(128), count: width * height * 3)
+    
+    // Test 1: Multiple exports in quick succession
+    for i in 0..<50 {
+        do {
+            let image = try VIPSImage(data: data, width: width, height: height, bands: 3, format: .uchar)
+            let _ = try image.exportedJpeg(quality: 80)
+            let _ = try image.exportedPNG()
+            if i % 10 == 0 {
+                print("Export iteration \(i)")
+            }
+        } catch {
+            print("Error at iteration \(i): \(error)")
+        }
+    }
+    
+    print("Stress test completed successfully")
+    VIPS.shutdown()
+}
+
+do {
+    try stressTestBlobHandling()
+} catch {
+    print("Fatal error: \(error)")
+}


### PR DESCRIPTION
## Summary
- Fixes incorrect manual unref calls on output blobs in VIPSImage extension
- Adds a new stress test executable target to validate blob handling under load

## Changes

### Core Fixes
- Removed manual `vips_area_unref` calls on output blobs in `VIPSImage` extension methods
- Added comments clarifying that `vips_object_unref_outputs` handles output blob unref

### New Stress Test
- Added `stress_test` executable target in `Package.swift` with dependencies on `VIPS` and `Cvips`
- Created `stress_test/main.swift` to perform repeated image exports (JPEG and PNG) to trigger and verify no assertion errors occur with blob unref
- Stress test creates a 100x100 image and exports it 50 times in quick succession, printing progress every 10 iterations

## Test plan
- Run the new stress test executable to ensure no `vips_area_unref` assertion errors occur
- Verify existing functionality remains stable with the fix
- Confirm that the stress test completes successfully without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f6b07044-8f4f-4f4b-a7c7-79d22a450f2b